### PR TITLE
Add IP Linux web desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ The web's biggest curated directory of apps, portfolios and experiments that mim
 [DAX Portal](https://dax-portal.vercel.app) | [![open](assets/open.png) available](https://github.com/201Harsh/DAX-Portal) |
 [Aria](https://sumanthkm.com/aria/) | [![open](assets/open.png) available](https://github.com/skmdroid/aria) |
 [Yuki OS](https://yukios.netlify.app) | [![open](assets/open.png) available](https://github.com/Reeyuki/YukiOS) |
+[IP Linux](https://ip-os-linux.vercel.app) | [![open](assets/open.png) available](https://github.com/ikerperez12/IP-OS-LINUX) | A polished React, Vite and TypeScript browser desktop environment with resizable windows, widgets, snap assist, virtual workspaces and local browser storage. |
 
 ## Archived
 


### PR DESCRIPTION
Please add IP Linux to the websites list. It is a polished local-first web desktop environment built with React, Vite, and TypeScript.